### PR TITLE
fix: 🐛 Update `01-getting-started.md` to the `ghq` style

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -29,7 +29,7 @@ git config --list
 To get a local copy of this repository, run:
 
 ```bash
-git get https://github.com/sforzando/etude-github.git
+ghq get https://github.com/sforzando/etude-github.git
 ```
 
 ## Practice Exercise

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -29,7 +29,7 @@ git config --list
 To get a local copy of this repository, run:
 
 ```bash
-git clone https://github.com/sforzando/etude-github.git
+git get https://github.com/sforzando/etude-github.git
 ```
 
 ## Practice Exercise


### PR DESCRIPTION
## Describe the PR

To close #16 

`git clone`を`ghq get`に直した

## Screenshots


<!--
## Detail of the change


- [x] A
- [ ] B
- [ ] C

## Anticipated impacts



## To reproduce

(T. B. D.)

Steps to check the behavior:

1. Update Libraries `...`
1. Import Database `...`
1. Reload Pages `...`
1. Click on `...`

-->

## Appendix




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the repository cloning instructions to use an alternative command method for obtaining a local copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->